### PR TITLE
fix/userControllers: do not send back full user data in server response

### DIFF
--- a/src/controllers/user/getSingleUser.js
+++ b/src/controllers/user/getSingleUser.js
@@ -14,7 +14,7 @@ export const getSingleUser = async (req, res, next) => {
       });
     }
     const { config, _id, username, email } = user;
-    res.status(200).json({ data: { config, id: _id, username, email } });
+    res.status(200).json({ data: { config, username, email } });
   } catch (error) {
     next(error);
   }

--- a/src/controllers/user/updateUser.js
+++ b/src/controllers/user/updateUser.js
@@ -20,7 +20,7 @@ export const updateUser = async (req, res, next) => {
     const { config, _id, username, email } = user;
     res.status(200).json({
       message: `User with id [${userId}] updated`,
-      data: { config, id: _id, username, email },
+      data: { id: _id },
     });
   } catch (error) {
     next(error);


### PR DESCRIPTION
Ich habe zwei ganz kleine Änderungen in updateUser und getSingleUser gemacht, damit nicht immer die ganze User-Data in der Response an den Client mitgeschickt wird (aus Sicherheitsgründen). In der API-Dokumentation habe ich es entsprechend geupdated.