### PR TITLE
refactoring/errorMiddleware: validation error handling added

### DIFF
--- a/src/middlewares/errorMiddleware.js
+++ b/src/middlewares/errorMiddleware.js
@@ -1,5 +1,16 @@
-// BASIC ERROR MIDDLEWARE
 export const errorMiddleware = (err, req, res, next) => {
+  // HANDLE VALIDATION ERRORS
+  if (err.name === "ValidationError") {
+    const errors = [];
+    for (const errField in err.errors) {
+      errors.push({
+        path: err.errors[errField].path,
+        message: err.errors[errField].message,
+      });
+    }
+    return res.status(400).json({ errorType: "ValidationError", errors });
+  }
+  // HANDLE OTHER ERRORS
   console.log("errorMiddleware:", err);
   res.status(500).json({ error: err });
 };


### PR DESCRIPTION
Ich habe bei errorMiddleware ein error handling spezifisch für validation errors erstellt, damit die validation errors in frontend  identifiziert und behandelt werden können. Der Grund: Das validation error von MongoDB ist ein besonderer Object namens ValidationError und irgendwie etwas anders als der typische Object strukturiert.