### PR TITLE
fix/checkinModel: adjust tagCategories to frontend categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Peacock Extension
+.vscode

--- a/src/models/checkinModel.js
+++ b/src/models/checkinModel.js
@@ -18,7 +18,7 @@ export const emotionFamilies = [
   "Entspannung",
   "Gemischte Gefühle",
 ];
-const tagCategories = ["wann", "wo", "mit wem", "was", "kontext"];
+const tagCategories = ["wann", "wo", "mitWem", "was"];
 
 const weatherOptions = ["sonnig", "bewölkt", "regnerisch", "wechselhaft"];
 


### PR DESCRIPTION
Bei Frontend gibt es bei tags keine Kategorie "kontext", sondern nur "was" (bei Frontend gibt es insgesamt eine Kategorie weniger als bei uns geplant war). Deshalb habe ich das checkinModel aktualisiert.