### PR TITLE
fix/postCheckin: update user instead of save to avoid full user validation in postCheckin

### DIFF
--- a/src/controllers/checkin/postCheckin.js
+++ b/src/controllers/checkin/postCheckin.js
@@ -9,6 +9,7 @@ export const postCheckin = async (req, res, next) => {
 
     // CREATE NEW CHECK-IN DOCUMENT
     const newCheckin = new Checkin(checkin);
+
     // FIND USER
     const user = await User.findById(userId);
 
@@ -25,8 +26,10 @@ export const postCheckin = async (req, res, next) => {
     await newCheckin.save();
 
     // SAVE CHANGES IN USER DOCUMENT
-    await user.save();
-
+    await User.updateOne(
+      { _id: userId },
+      { $push: { checkins: newCheckin._id } }
+    );
     res.status(201).json({
       message: "Check-in created succesfully",
       data: newCheckin,


### PR DESCRIPTION
Bei einigen Passwörtern (ich denke, solche, die mit einem Buchstaben anfangen wie z.B. 1234nadja! oder 1234abcd!) gab es bei postCheckin einen Error "password format invalid", der in postCheckin durch await User.save() ausgelöst wurde, weil dort wohl nochmal die komplette user data validiert wurde. 

Warum einige Passwörter Fehler werfen und andere (wie nadja1234! oder abcd1234!) nicht, konnte ich nicht nachvollziehen. Ich vermute es liegt am Zeitpunkt von Validierung und Hashing. Beim Registrieren/Login erzeugen diese Passwörter nämlich keinen Fehler sondern erst bei postCheckin. 

Jedenfalls kann das Problem mit update statt save umgangen werden (weil dann user nicht mehr validiert wird) und sollte dann jetzt korrekt funktionieren.