### PR TITLE
fix/login: keep cookie for 1 hour if user does not wish to be remembered, fix logout

### DIFF
--- a/src/controllers/auth/login.js
+++ b/src/controllers/auth/login.js
@@ -59,7 +59,7 @@ export const login = async (req, res, next) => {
 
     // SET COOKIE
     res.cookie("accessToken", accessToken, {
-      maxAge: stayLoggedIn ? 604800000 : 0, // cookie stays for 7 days if user wants to stay logged in
+      maxAge: stayLoggedIn ? 604800000 : 3600 * 1000, // cookie stays for 7 days if user wants to stay logged in, otherwise 1 hour
       httpOnly: true,
       sameSite: "Strict",
       secure: true,

--- a/src/controllers/auth/logout.js
+++ b/src/controllers/auth/logout.js
@@ -3,7 +3,11 @@
 export const logout = async (req, res, next) => {
   try {
     // CLEAR COOKIE
-    res.clearCookie("accessToken");
+    res.clearCookie("accessToken", {
+      httpOnly: true,
+      sameSite: "Strict",
+      secure: true,
+    });
     res.status(200).json({ message: "Logout successfull" });
   } catch (error) {
     next(error);


### PR DESCRIPTION
Wenn User nicht "remember me" ankreuzt, wird der Cookie sofort gelöscht und wegen fehlender Authentication ist es dann gar nicht möglich, die App zu benutzen. Ich habe deshalb die Cookie-Zeit für diesen Fall auf 1 Stunde gesetzt. Ist nicht so sauber, aber einfach als schneller Workaround für den Moment.