### PR TITLE
fix/getStatisticsByTag: only include emotion families with count > 0 in server response

### DIFF
--- a/src/controllers/stats/getStatisticsByTag.js
+++ b/src/controllers/stats/getStatisticsByTag.js
@@ -42,10 +42,13 @@ export const getStatisticsByTag = async (req, res, next) => {
         }
       });
     });
+    const filteredStats = stats.filter((family) => family.count > 0);
 
     res
       .status(200)
-      .json({ data: { tag: tag, stats, total: checkinsByTag.length } });
+      .json({
+        data: { tag: tag, stats: filteredStats, total: checkinsByTag.length },
+      });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
Ich habe eine Kleinigkeit in getStatisticsByTag angepasst, damit es einheitlich zu getStatisticsByFamily ist. Nämlich dass families mit count: 0 gar nicht in der response enthalten sind.